### PR TITLE
Add markdown-language scope to defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "source.asciidoc",
         "source.gfm",
         "text.git-commit",
+        "text.md",
         "text.plain",
         "text.plain.null-grammar"
       ],


### PR DESCRIPTION
The markdown-language package replaces language-gfm.   Add the text.md to the default grammars  list so spellcheck works for markdown.
